### PR TITLE
_reflector.getType replaced with Type.getType

### DIFF
--- a/src/org/swiftsuspenders/Injector.hx
+++ b/src/org/swiftsuspenders/Injector.hx
@@ -434,7 +434,12 @@ class Injector extends EventDispatcher
 	 */
 	public function injectInto(target:Dynamic):Void
 	{
+		#if (haxe_ver >= 3.40)
 		var type:Class<Dynamic> = Type.getClass(target);
+		#else
+		var type:Class<Dynamic> = _reflector.getClass(target);
+		#end		
+		
 		applyInjectionPoints(target, type, _classDescriptor.getDescription(type));
 	}
 
@@ -550,7 +555,13 @@ class Injector extends EventDispatcher
 	public function destroyInstance(instance:Dynamic):Void
 	{
 		_managedObjects.remove(UID.clearInstanceID(instance));
+		
+		#if (haxe_ver >= 3.40)
 		var type:Class<Dynamic> = Type.getClass(instance);
+		#else
+		var type:Class<Dynamic> = _reflector.getClass(instance);
+		#end		
+
 		var typeDescription:TypeDescription = getTypeDescription(type);
 		// FIX
 		/*for (var preDestroyHook:PreDestroyInjectionPoint = typeDescription.preDestroyMethods; preDestroyHook; preDestroyHook = PreDestroyInjectionPoint(preDestroyHook.next))

--- a/src/org/swiftsuspenders/Injector.hx
+++ b/src/org/swiftsuspenders/Injector.hx
@@ -438,7 +438,7 @@ class Injector extends EventDispatcher
 		var type:Class<Dynamic> = Type.getClass(target);
 		#else
 		var type:Class<Dynamic> = _reflector.getClass(target);
-		#end		
+		#end
 		
 		applyInjectionPoints(target, type, _classDescriptor.getDescription(type));
 	}

--- a/src/org/swiftsuspenders/Injector.hx
+++ b/src/org/swiftsuspenders/Injector.hx
@@ -434,7 +434,7 @@ class Injector extends EventDispatcher
 	 */
 	public function injectInto(target:Dynamic):Void
 	{
-		var type:Class<Dynamic> = _reflector.getClass(target);
+		var type:Class<Dynamic> = Type.getClass(target);
 		applyInjectionPoints(target, type, _classDescriptor.getDescription(type));
 	}
 
@@ -550,7 +550,7 @@ class Injector extends EventDispatcher
 	public function destroyInstance(instance:Dynamic):Void
 	{
 		_managedObjects.remove(UID.clearInstanceID(instance));
-		var type:Class<Dynamic> = _reflector.getClass(instance);
+		var type:Class<Dynamic> = Type.getClass(instance);
 		var typeDescription:TypeDescription = getTypeDescription(type);
 		// FIX
 		/*for (var preDestroyHook:PreDestroyInjectionPoint = typeDescription.preDestroyMethods; preDestroyHook; preDestroyHook = PreDestroyInjectionPoint(preDestroyHook.next))


### PR DESCRIPTION
After updating lime _reflector.getType is not returning proper values, using Type.getType instead fixes it